### PR TITLE
Fixed demo notebook to get raw data file, ignore PyCS trial data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ target/
 
 # Backup files
 *~
+
+# Data
+trialcurves.txt

--- a/notebooks/Demo.ipynb
+++ b/notebooks/Demo.ipynb
@@ -32,15 +32,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 6,
    "metadata": {
     "collapsed": false
    },
    "outputs": [],
    "source": [
-    "webdir = 'https://github.com/COSMOGRAIL/PyCS/blob/master/demo/demo1/data/'\n",
+    "webdir = 'https://raw.githubusercontent.com/COSMOGRAIL/PyCS/master/demo/demo1/data/'\n",
     "lcfile = 'trialcurves.txt'\n",
-    "\n",
+    "    \n",
     "url = os.path.join(webdir, lcfile)\n",
     "if not os.path.isfile(lcfile):\n",
     "    urllib.urlretrieve(url, lcfile)"
@@ -48,7 +48,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 7,
    "metadata": {
     "collapsed": false
    },
@@ -57,7 +57,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    1304 trialcurves.txt\r\n"
+      "     194 trialcurves.txt\r\n"
      ]
     }
    ],


### PR DESCRIPTION
Hi @drphilmarshall , 

I found a bug where the trialcurves.txt file wasn't downloading correctly. Please could you merge ASAP? Thanks!

Milan
